### PR TITLE
hci interface as list

### DIFF
--- a/custom_components/ble_monitor/config_flow.py
+++ b/custom_components/ble_monitor/config_flow.py
@@ -53,8 +53,8 @@ DEVICE_SCHEMA = vol.Schema(
 DOMAIN_SCHEMA = vol.Schema(
     {
         vol.Optional(
-            CONF_HCI_INTERFACE, default=DEFAULT_HCI_INTERFACE
-        ): cv.positive_int,
+            CONF_HCI_INTERFACE, default=[DEFAULT_HCI_INTERFACE]
+        ): cv.multi_select({"0": "0", "1": "1", "2": "2"}),
         vol.Optional(CONF_DISCOVERY, default=DEFAULT_DISCOVERY): cv.boolean,
         vol.Optional(CONF_ACTIVE_SCAN, default=DEFAULT_ACTIVE_SCAN): cv.boolean,
         vol.Optional(
@@ -131,7 +131,7 @@ class BLEMonitorOptionsFlow(config_entries.OptionsFlow):
             {
                 vol.Optional(
                     CONF_HCI_INTERFACE, default=self.config_entry.options.get(CONF_HCI_INTERFACE, DEFAULT_HCI_INTERFACE)
-                ): cv.positive_int,
+                ): cv.multi_select({"0": "0", "1": "1", "2": "2"}),
                 vol.Optional(CONF_DISCOVERY, default=self.config_entry.options.get(CONF_DISCOVERY, DEFAULT_DISCOVERY)): cv.boolean,
                 vol.Optional(CONF_ACTIVE_SCAN, default=self.config_entry.options.get(CONF_ACTIVE_SCAN, DEFAULT_ACTIVE_SCAN)): cv.boolean,
                 vol.Optional(


### PR DESCRIPTION
I´ve changed the HCIinterface input from one value to a multiple selection list. In this way we can select 0, 1 or 2 as hci interface, and this doesn´t have to be limited to one value.

![image](https://user-images.githubusercontent.com/24375847/100200492-ff04af00-2efe-11eb-8d55-0d43cd6c9491.png)

For some strange reason, it can only create a list with strings (I tried integers, but that didn't work), so in `sensor.py` I had to convert the list with strings back to integers. 

Also fixed an error message that wasn't dealt with nicely, if you select an interface that isn't available.

